### PR TITLE
add package-version testing and fix version mismatch

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,5 @@ node_modules
 /node_modules
 test
 ba
+.travis.yml
+appveyor.yml

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "name": "lightify",
-    "version": "0.0.24",
+    "version": "0.0.25",
     "title": "OSRAM Lightify",
     "desc": {
       "en": "OSRAM Lightify Devices",

--- a/test/testPackageFiles.js
+++ b/test/testPackageFiles.js
@@ -21,7 +21,7 @@ describe('Test package.json and io-package.json', function() {
             console.log('ERROR: Version numbers in package.json and io-package.json differ!!');
         }
 
-        if (!ioPackage.common.news[ioPackage.common.version]) {
+        if (!ioPackage.common.news || !ioPackage.common.news[ioPackage.common.version]) {
             console.log('WARNING: No news entry for current version exists in io-package.json, no rollback in Admin possible!');
         }
 

--- a/test/testPackageFiles.js
+++ b/test/testPackageFiles.js
@@ -1,0 +1,30 @@
+/* jshint -W097 */// jshint strict:false
+/*jslint node: true */
+var expect = require('chai').expect;
+var fs        = require('fs');
+
+describe('Test package.json and io-package.json', function() {
+    it('Test package files', function (done) {
+        var fileContentIOPackage = fs.readFileSync(__dirname + '/../io-package.json');
+        var ioPackage = JSON.parse(fileContentIOPackage);
+
+        var fileContentNPMPackage = fs.readFileSync(__dirname + '/../package.json');
+        var npmPackage = JSON.parse(fileContentNPMPackage);
+
+        expect(ioPackage).to.be.an('object');
+        expect(npmPackage).to.be.an('object');
+
+        expect(ioPackage.common.version).to.exist;
+        expect(npmPackage.version).to.exist;
+
+        if (!expect(ioPackage.common.version).to.be.equal(npmPackage.version)) {
+            console.log('ERROR: Version numbers in package.json and io-package.json differ!!');
+        }
+
+        if (!ioPackage.common.news[ioPackage.common.version]) {
+            console.log('WARNING: No news entry for current version exists in io-package.json, no rollback in Admin possible!');
+        }
+
+        done();
+    });
+});


### PR DESCRIPTION
I assume you need to publish a completely new version to fix this for the users (because they will see an open update any time in admin, but there is none)