### PR TITLE
soef@0.4.3 has errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.lightify",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "OSRAM Lightify Adapter",
   "author": {
     "name": "soef",
@@ -29,7 +29,7 @@
     "mdns-discovery": "^0.2.2"
   },
   "dependencies": {
-    "soef": "^0.4.0",
+    "soef": "0.4.0",
     "promise": ">=7.1.1",
     "moment": ">=2.4.0"
   },


### PR DESCRIPTION
```
D:\pWork\node_modules\iobroker.lightify\node_modules\soef\soef.js:1322
    fns.adapter = fns.adapter(options);
                      ^

TypeError: fns.adapter is not a function
```